### PR TITLE
Massively refactored to fix bugs and use double

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,11 @@
 *.exe
 *.out
 *.app
+
+# IDEs
+.idea/
+CMakeLists.txt
+cmake-build-debug/
+
+# Temporaries
+singletask.lock

--- a/dbus/dbus.hpp
+++ b/dbus/dbus.hpp
@@ -91,7 +91,7 @@ public:
         }
         catch (const std::exception& e)
         {
-            std::cerr << "Get dbus properties fail. " << e.what() << std::endl;
+            // std::cerr << "Get dbus properties fail. " << e.what() << std::endl;
             return value;
         }
 
@@ -119,7 +119,7 @@ public:
         // Sensors in floating-point use nan to indicate error
         if (std::isnan(value))
         {
-            std::cerr << "Sensor Value reading not available: " << path << std::endl;
+            // std::cerr << "Sensor Value reading not available: " << path << std::endl;
         }
         return value;
     }

--- a/dbus/dbus.hpp
+++ b/dbus/dbus.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <map>
 #include <variant>
+#include <cmath>
 
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/bus/match.hpp>
@@ -26,14 +27,13 @@ public:
      * @param[in] bus - bus.
      * @param[in] busName - bus name.
      * @param[in] objPath - object path.
-     * @param[in] value - value to be set.
+     * @param[in] value - value to be set, in degrees, regardless of unitMilli.
+     * @param[in] unitMilli - true to set millidegrees, false to set degrees.
      */
-    static auto
+    static void
         setValueProperty(sdbusplus::bus::bus& bus, const std::string& busName,
-            const std::string& objPath, const int64_t& value)
+            const std::string& objPath, const double& value, bool unitMilli)
     {
-        std::variant<double> data = (double)value / 1000;
-
         try
         {
             auto methodCall = bus.new_method_call(
@@ -41,14 +41,27 @@ public:
 
             methodCall.append(valueInterface);
             methodCall.append("Value");
-            methodCall.append(data);
+
+            // Using millidegrees on D-Bus seems to need int64_t not double
+            if (unitMilli)
+            {
+                // Convert degrees to millidegrees
+                auto intValue = static_cast<int64_t>(value * 1000.0);
+
+                // Send as int64_t not double
+                methodCall.append(std::variant<int64_t>(intValue));
+            }
+            else
+            {
+                // Send as double
+                methodCall.append(std::variant<double>(value));
+            }
 
             auto reply = bus.call(methodCall);
         }
         catch (const std::exception& e)
         {
             std::cerr << "Set dbus properties fail. " << e.what() << std::endl;
-            return;
         }
     }
 
@@ -58,15 +71,18 @@ public:
      * @param[in] bus - bus.
      * @param[in] service - dbus service name.
      * @param[in] path - dbus path.
-     * @return Value from dbus.
+     * @param[in] unitMilli - true to get millidegrees, false to get degrees.
+     * @return Value from dbus, in degrees, regardless of unitMilli.
      */
     static double getValueProperty(sdbusplus::bus::bus& bus,
-        const std::string& service, const std::string& path)
+        const std::string& service, const std::string& path, bool unitMilli)
     {
         propertyMap propMap;
         auto pimMsg = bus.new_method_call(service.c_str(), path.c_str(),
             dbusPropertyInterface, "GetAll");
         pimMsg.append(valueInterface);
+
+        double value = std::numeric_limits<double>::quiet_NaN();
 
         try
         {
@@ -76,10 +92,36 @@ public:
         catch (const std::exception& e)
         {
             std::cerr << "Get dbus properties fail. " << e.what() << std::endl;
-            return -1;
+            return value;
         }
 
-        return std::get<double>(propMap["Value"]);
+        // Using millidegrees on D-Bus seems to need int64_t not double
+        if (unitMilli)
+        {
+            // Receive as int64_t not double
+            auto intValue = std::get<int64_t>(propMap["Value"]);
+
+            // Sensors in integer use -1 to indicate error
+            if (intValue != -1)
+            {
+                // Convert millidegrees to degrees
+                // Avoid loss of precision by first casting to double
+                value = static_cast<double>(intValue);
+                value /= 1000.0;
+            }
+        }
+        else
+        {
+            // Receive as double
+            value = std::get<double>(propMap["Value"]);
+        }
+
+        // Sensors in floating-point use nan to indicate error
+        if (std::isnan(value))
+        {
+            std::cerr << "Sensor Value reading not available: " << path << std::endl;
+        }
+        return value;
     }
 };
 }

--- a/main.cpp
+++ b/main.cpp
@@ -16,17 +16,17 @@ constexpr auto marginConfigPath =
 std::map<std::string, struct conf::sensorConfig> sensorConfig = {};
 conf::skuConfig skusConfig;
 
-void run()
+void run(const std::string& configPath)
 {
     try
     {
-        auto jsonData = parseValidateJson(marginConfigPath);
+        auto jsonData = parseValidateJson(configPath);
         sensorConfig = getSensorInfo(jsonData);
         skusConfig = getSkuInfo(jsonData);
     }
     catch (const std::exception& e)
     {
-        std::cerr << "Failed during building json file: " << e.what() << "\n";
+        std::cerr << "Failed during building json file: " << e.what() << std::endl;
         exit(EXIT_FAILURE);
     }
 
@@ -40,9 +40,16 @@ void run()
     updateMarginTempLoop(skuConfig, sensorConfig);
 }
 
-int main()
+int main(int argc, char **argv)
 {
-    run();
+    std::string configPath = marginConfigPath;
+
+    if (argc > 1)
+    {
+        configPath = argv[1];
+    }
+
+    run(configPath);
 
     return 0;
 }

--- a/sensor/sensor.cpp
+++ b/sensor/sensor.cpp
@@ -10,7 +10,7 @@ std::string getSensorHwmonNum(std::string partialPath)
 {
     auto dir = opendir(partialPath.c_str());
 
-    while ((dir != NULL) && ((drnt = readdir(dir)) != NULL)) 
+    while ((dir != NULL) && ((drnt = readdir(dir)) != NULL))
     {
         std::string hwmonNum(drnt->d_name);
         if (hwmonNum.find("hwmon") != std::string::npos)

--- a/util/util.cpp
+++ b/util/util.cpp
@@ -38,7 +38,7 @@ double getSensorDbusTemp(std::string sensorDbusPath, bool unitMilli)
 
     if (service.empty())
     {
-        std::cerr << "Sensor input path not mappable to service: " << sensorDbusPath << std::endl;
+        // std::cerr << "Sensor input path not mappable to service: " << sensorDbusPath << std::endl;
         return value;
     }
 
@@ -89,7 +89,7 @@ double getSpecTemp(struct conf::sensorConfig config)
 
     if (std::isnan(specTemp))
     {
-        std::cerr << "Sensor MaxTemp reading not available: " << config.parametersPath << std::endl;
+        // std::cerr << "Sensor MaxTemp reading not available: " << config.parametersPath << std::endl;
     }
     else
     {
@@ -148,13 +148,13 @@ std::string getService(const std::string path)
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {
-        std::cerr << "Get dbus service fail. " << ex.what() << std::endl;
+        // std::cerr << "Get dbus service fail. " << ex.what() << std::endl;
         return "";
     }
 
     if (response.begin() == response.end())
     {
-        std::cerr << "Sensor service not found: " << path << std::endl;
+        // std::cerr << "Sensor service not found: " << path << std::endl;
         return "";
     }
 
@@ -168,7 +168,7 @@ void updateDbusMarginTemp(int zoneNum, double marginTemp, std::string targetpath
 
     if (service.empty())
     {
-        std::cerr << "Sensor output path not mappable to service: " << targetpath << std::endl;
+        // std::cerr << "Sensor output path not mappable to service: " << targetpath << std::endl;
         return;
     }
 

--- a/util/util.cpp
+++ b/util/util.cpp
@@ -4,6 +4,7 @@
 #include <thread>
 #include <map>
 #include <vector>
+#include <iostream>
 
 #include <sdbusplus/server.hpp>
 #include <sdbusplus/bus.hpp>
@@ -13,6 +14,9 @@
 #include "util/util.hpp"
 #include "sensor/sensor.hpp"
 #include "dbus/dbus.hpp"
+
+// Enables logging of margin decisions
+static constexpr bool DEBUG = false;
 
 int getSkuNum()
 {
@@ -25,29 +29,40 @@ int getSkuNum()
     return 1;
 }
 
-int getSensorDbusTemp(std::string sensorDbusPath)
+double getSensorDbusTemp(std::string sensorDbusPath, bool unitMilli)
 {
     auto bus = sdbusplus::bus::new_default();
     std::string service = getService(sensorDbusPath);
 
+    double value = std::numeric_limits<double>::quiet_NaN();
+
     if (service.empty())
     {
-        return -1;
+        std::cerr << "Sensor input path not mappable to service: " << sensorDbusPath << std::endl;
+        return value;
     }
 
-    auto temp = dbus::SDBusPlus::getValueProperty(bus, service, sensorDbusPath);
-
-    return (int)(temp * 1000);
+    value = dbus::SDBusPlus::getValueProperty(bus, service, sensorDbusPath, unitMilli);
+    return value;
 }
 
-int getSpecTemp(struct conf::sensorConfig config)
+// As per documentation, specTemp unit, in config or filesystem, is always millidegrees
+// However, this function returns degrees
+double getSpecTemp(struct conf::sensorConfig config)
 {
+    double specTemp = std::numeric_limits<double>::quiet_NaN();
+
+    // As per documentation, -1 indicates "value comes from outside the config"
     if (config.parametersMaxTemp != -1)
     {
-        return config.parametersMaxTemp;
+        // The value is within the config itself, use it as-is
+        specTemp = static_cast<double>(config.parametersMaxTemp);
+
+        // Convert millidegrees to degrees
+        specTemp /= 1000.0;
+        return specTemp;
     }
 
-    int specTemp = -1;
     std::fstream sensorSpecFile;
 
     if (config.parametersType == "sys")
@@ -59,9 +74,8 @@ int getSpecTemp(struct conf::sensorConfig config)
         if (sensorSpecFile)
         {
             sensorSpecFile >> specTemp;
+            sensorSpecFile.close();
         }
-
-        sensorSpecFile.close();
     }
     else if (config.parametersType == "file")
     {
@@ -69,22 +83,47 @@ int getSpecTemp(struct conf::sensorConfig config)
         if (sensorSpecFile)
         {
             sensorSpecFile >> specTemp;
+            sensorSpecFile.close();
         }
+    }
 
-        sensorSpecFile.close();
+    if (std::isnan(specTemp))
+    {
+        std::cerr << "Sensor MaxTemp reading not available: " << config.parametersPath << std::endl;
+    }
+    else
+    {
+        // Convert millidegrees to degrees
+        specTemp /= 1000.0;
     }
 
     return specTemp;
 }
 
-int calOffsetValue(int setPoint, double scalar, int maxTemp, int targetTemp, int targetOffset)
+// Avoid losing precision by doing calculations as double
+double calOffsetValue(int setPointInt, double scalar, double maxTemp, int targetTempInt, int targetOffsetInt)
 {
-    int offsetvalue = 0;
+    // All integers are in millidegrees, convert to degrees
+    double setPoint = static_cast<double>(setPointInt);
+    setPoint /= 1000.0;
+    double targetOffset = static_cast<double>(targetOffsetInt);
+    targetOffset /= 1000.0;
+
+    double offsetvalue = 0.0;
     offsetvalue = setPoint / scalar;
-    if (targetTemp == -1)
+
+    // If targetTemp not specified, use maxTemp instead
+    double targetTemp;
+    if (targetTempInt == -1)
     {
         targetTemp = maxTemp;
     }
+    else
+    {
+        targetTemp = static_cast<double>(targetTempInt);
+        targetTemp /= 1000.0;
+    }
+
     offsetvalue -= maxTemp - ( targetTemp + targetOffset );
     return offsetvalue;
 }
@@ -109,23 +148,32 @@ std::string getService(const std::string path)
     }
     catch (const sdbusplus::exception::SdBusError& ex)
     {
+        std::cerr << "Get dbus service fail. " << ex.what() << std::endl;
         return "";
     }
 
     if (response.begin() == response.end())
     {
+        std::cerr << "Sensor service not found: " << path << std::endl;
         return "";
     }
 
     return response.begin()->first;
 }
 
-void updateDbusMarginTemp(int zoneNum, int64_t marginTemp, std::string targetpath)
+void updateDbusMarginTemp(int zoneNum, double marginTemp, std::string targetpath)
 {
     auto bus = sdbusplus::bus::new_default();
-    std::string service = "xyz.openbmc_project.Hwmon.external";
+    std::string service = getService(targetpath);
 
-    dbus::SDBusPlus::setValueProperty(bus, service, targetpath, marginTemp);
+    if (service.empty())
+    {
+        std::cerr << "Sensor output path not mappable to service: " << targetpath << std::endl;
+        return;
+    }
+
+    // The final computed margin output is always in degrees
+    dbus::SDBusPlus::setValueProperty(bus, service, targetpath, marginTemp, false);
 }
 
 void updateMarginTempLoop(
@@ -134,11 +182,11 @@ void updateMarginTempLoop(
 {
     std::fstream sensorTempFile;
     int numOfZones = skuConfig.size();
-    int sensorRealTemp;
-    int sensorSpecTemp;
-    int sensorMarginTemp;
-    int sensorCalibTemp;
-    int64_t calibMarginTemp;
+    double sensorRealTemp;
+    double sensorSpecTemp;
+    double sensorMarginTemp;
+    double sensorCalibTemp;
+    double calibMarginTemp;
     std::map<std::string, struct conf::sensorConfig> sensorList[numOfZones];
 
     for (int i = 0; i < numOfZones; i++)
@@ -153,90 +201,171 @@ void updateMarginTempLoop(
     {
         for (int i = 0; i < numOfZones; i++)
         {
-            calibMarginTemp = -1;
+            // Begin a new zone line of space-separated sensors
+            if constexpr (DEBUG)
+            {
+                // Get the map key at the Nth position within the map
+                auto t = skuConfig.begin();
+                for (int j = 0; j < i; ++j)
+                {
+                    // Unfortunately, no operator+=, can't just do t += i
+                    ++t;
+                }
+
+                std::cerr << "Margin Zone " << t->first << ":";
+            }
+
+            // Standardize on floating-point degrees for all computations
+            calibMarginTemp = std::numeric_limits<double>::quiet_NaN();
+
             for (auto t = sensorList[i].begin(); t != sensorList[i].end(); t++)
             {
-                sensorRealTemp = 0;
-                if (sensorList[i][t->first].parametersMaxTemp == -1)
+                // Numbers from D-Bus or filesystem need to know their units
+                bool incomingMilli = false;
+                if ((sensorList[i][t->first].unit == "millidegree") || (sensorList[i][t->first].unit == "millimargin"))
                 {
-                    sensorSpecTemp =
-                        getSpecTemp(sensorList[i][t->first]);
+                   incomingMilli = true;
+                }
+
+                // Also need to know if units are absolute or margin
+                bool incomingMargin = false;
+                if ((sensorList[i][t->first].unit == "margin") || (sensorList[i][t->first].unit == "millimargin"))
+                {
+                    incomingMargin = true;
+                }
+
+                sensorRealTemp = std::numeric_limits<double>::quiet_NaN();
+
+                // This function already returns degrees
+                sensorSpecTemp =
+                    getSpecTemp(sensorList[i][t->first]);
+
+                if (sensorList[i][t->first].type == "dbus")
+                {
+                    // This function already returns degrees
+                    sensorRealTemp =
+                        getSensorDbusTemp(sensorList[i][t->first].path, incomingMilli);
                 }
                 else
                 {
-                    sensorSpecTemp = sensorList[i][t->first].parametersMaxTemp;
-                }
+                    if (sensorList[i][t->first].type == "sys")
+                    {
+                        std::string path;
 
-                if (sensorList[i][t->first].type == "sys")
-                {
-                    std::string path;
-
-                    path = getSysPath(t->second.path);
-                    sensorTempFile.open(path, std::ios::in);
-                    if (sensorTempFile)
-                    {
-                        sensorTempFile >> sensorRealTemp;
+                        path = getSysPath(t->second.path);
+                        sensorTempFile.open(path, std::ios::in);
+                        if (sensorTempFile)
+                        {
+                            sensorTempFile >> sensorRealTemp;
+                            sensorTempFile.close();
+                        }
                     }
-                    else
+                    else if (sensorList[i][t->first].type == "file")
                     {
-                        sensorTempFile.close();
-                        continue;
-                    }
-                    
-                    sensorTempFile.close();
-                }
-                else if (sensorList[i][t->first].type == "dbus")
-                {
-                    sensorRealTemp = 
-                        getSensorDbusTemp(sensorList[i][t->first].path);
-                }
-                else if (sensorList[i][t->first].type == "file")
-                {
-                    std::fstream sensorValueFile;
-                    sensorValueFile.open(sensorList[i][t->first].path, std::ios::in);
-                    if (sensorValueFile)
-                    {
-                        sensorValueFile >> sensorRealTemp;
+                        std::fstream sensorValueFile;
+                        sensorValueFile.open(sensorList[i][t->first].path, std::ios::in);
+                        if (sensorValueFile)
+                        {
+                            sensorValueFile >> sensorRealTemp;
+                            sensorValueFile.close();
+                        }
                     }
 
-                    sensorValueFile.close();
+                    if (!(std::isnan(sensorRealTemp)))
+                    {
+                        // If configured unit not already degrees, convert to degrees
+                        if (incomingMilli)
+                        {
+                            sensorRealTemp /= 1000.0;
+                        }
+                    }
                 }
 
-                if (sensorList[i][t->first].unit == "degree")
+                if (std::isnan(sensorRealTemp))
                 {
-                    sensorRealTemp *= 1000;
-                    sensorSpecTemp *= 1000;
+                    // Sensor failure, unable to get reading
+                    if constexpr (DEBUG)
+                    {
+                        std::cerr << " ?";
+                    }
+
+                    continue;
                 }
-                else if (sensorList[i][t->first].unit == "millimargin"){
-                    if (calibMarginTemp == -1 ||
+
+                // If sensor already in margin, then accept it as-is
+                if (incomingMargin)
+                {
+                    // Remember this margin if it is the worst margin
+                    if ((std::isnan(calibMarginTemp)) ||
                         sensorRealTemp < calibMarginTemp)
                     {
                         calibMarginTemp = sensorRealTemp;
                     }
+
+                    // Sensor successful, already in margin format
+                    if constexpr (DEBUG)
+                    {
+                        std::cerr << " " << sensorRealTemp;
+                    }
+
                     continue;
                 }
 
-                if (sensorRealTemp != -1)
+                if (std::isnan(sensorSpecTemp))
                 {
-                    sensorMarginTemp = (sensorSpecTemp - sensorRealTemp);
-                    sensorCalibTemp = sensorMarginTemp;
-                    auto offsetVal = calOffsetValue(skuConfig[i].first.first,
-                                                    sensorList[i][t->first].parametersScalar,
-                                                    sensorSpecTemp,
-                                                    sensorList[i][t->first].parametersTargetTemp,
-                                                    sensorList[i][t->first].parametersTargetTempOffset);
-                    sensorCalibTemp += offsetVal;
-                    sensorCalibTemp *= sensorList[i][t->first].parametersScalar;
-
-                    if (calibMarginTemp == -1 ||
-                        sensorCalibTemp < calibMarginTemp)
+                    // Sensor failure, needed to know sensorSpecTemp to compute margin
+                    if constexpr (DEBUG)
                     {
-                        calibMarginTemp = sensorCalibTemp;
+                        std::cerr << " ?";
                     }
+
+                    continue;
+                }
+
+                // Subtract to compute margin
+                sensorMarginTemp = (sensorSpecTemp - sensorRealTemp);
+                sensorCalibTemp = sensorMarginTemp;
+
+                // The first parameter: this is the setPoint, integer millidegrees
+                // parametersScalar: floating-point, this is unitless
+                // sensorSpecTemp: floating-point degrees
+                // parametersTargetTemp and TargetTempOffset: integer millidegrees
+                auto offsetVal = calOffsetValue(skuConfig[i].first.first,
+                                                sensorList[i][t->first].parametersScalar,
+                                                sensorSpecTemp,
+                                                sensorList[i][t->first].parametersTargetTemp,
+                                                sensorList[i][t->first].parametersTargetTempOffset);
+                sensorCalibTemp += offsetVal;
+                sensorCalibTemp *= sensorList[i][t->first].parametersScalar;
+
+                // Remember this margin if it is the worst margin
+                if ((std::isnan(calibMarginTemp)) ||
+                    sensorCalibTemp < calibMarginTemp)
+                {
+                    calibMarginTemp = sensorCalibTemp;
+                }
+
+                // Sensor successful, converted absolute to margin
+                if constexpr (DEBUG)
+                {
+                    std::cerr << " " << sensorCalibTemp;
                 }
             }
 
+            // If all sensors failed, conservatively assume we have no margin
+            if (std::isnan(calibMarginTemp))
+            {
+                calibMarginTemp = 0;
+            }
+
             updateDbusMarginTemp(i, calibMarginTemp, skuConfig[i].first.second);
+
+            // Finish sensor line, indicate computed worst margin
+            if constexpr (DEBUG)
+            {
+                std::cerr << " => " << calibMarginTemp << std::endl;
+            }
+
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }

--- a/util/util.hpp
+++ b/util/util.hpp
@@ -19,7 +19,7 @@ int getSkuNum();
  * @param[in] sensorDbusPath - sensor dbus path.
  * @return Sensor temp.
  */
-int getSensorDbusTemp(std::string sensorDbusPath);
+double getSensorDbusTemp(std::string sensorDbusPath);
 
 /**
  * Get spec temp.
@@ -27,19 +27,19 @@ int getSensorDbusTemp(std::string sensorDbusPath);
  * @param[in] config - sensor config.
  * @return Spec temp of the sensor.
  */
-int getSpecTemp(struct conf::sensorConfig config);
+double getSpecTemp(struct conf::sensorConfig config);
 
 /**
  * Calculate margin offset value.
  *
- * @param[in] setPoint - zone setpoint.
- * @param[in] scalar - sensor scalar.
- * @param[in] maxTemp - sensor max temp.
- * @param[in] targetTemp - sensor target temp.
- * @param[in] targetOffset - sensor target temp offset.
+ * @param[in] setPoint - zone setpoint, integer millidegrees.
+ * @param[in] scalar - sensor scalar, floating-point, this is unitless.
+ * @param[in] maxTemp - sensor max temp, floating-point degrees.
+ * @param[in] targetTemp - sensor target temp, integer millidegrees.
+ * @param[in] targetOffset - sensor target temp offset, integer millidegrees.
  * @return Margin offset.
  */
-int calOffsetValue(int setPoint, double scalar, int maxTemp, int targetTemp, int targetOffset = 0);
+double calOffsetValue(int setPoint, double scalar, double maxTemp, int targetTemp, int targetOffset = 0);
 
 /**
  * Get dbus service name.


### PR DESCRIPTION
Now uses floating-point double for all internal math
Converts to/from integer millidegrees only as needed during I/O
This solves many "off by a factor of 1000" bugs
This also makes offset/compensation/calibration more precise
Still accepting all 4 combinations: ["milli"]("degree" | "margin")

Now uses variants, as required by recent D-Bus schema
Checks for floating-point NAN and avoids accepting it
Still recognizing -1 in integer millidegrees as NAN equivalent

Now properly looks up appropriate service for each object path
Sensors are no longer limited to use only "Hwmon.external" service

Optional DEBUG constant enables printing useful line of logging
This line shows all margins considered, and the final worst margin chosen
Each zone has its own line, with zone ID number to tell them apart

Plugged file descriptor leak by closing all files successfully opened

JSON config file location may now be customized on command line

Cosmetic cleanup, such as removing trailing whitespace
Added a few more useful error messages
Added more temporary editor files to .gitignore list

Signed-off-by: Josh Lehan <krellan@google.com>