### PR TITLE
Add single point of failure mode and error detect

### DIFF
--- a/dbus/dbus.hpp
+++ b/dbus/dbus.hpp
@@ -121,7 +121,7 @@ class SDBusPlus
             }
 
             // Sensors in floating-point use nan to indicate error
-            if (std::isnan(value))
+            if (!(std::isfinite(value)))
             {
                 // std::cerr << "Sensor Value reading not available: " << path << std::endl;
             }

--- a/main.cpp
+++ b/main.cpp
@@ -13,6 +13,12 @@
 constexpr auto MARGINCONFIGPATH =
     "/usr/share/read-margin-temp/config-margin.json";
 
+constexpr auto debugEnablePath = "/etc/thermal.d/margindebug";
+extern bool debugEnabled;
+
+constexpr auto spofDisablePath = "/etc/thermal.d/spofdisable";
+extern bool spofEnabled;
+
 std::map<std::string, struct conf::SensorConfig> sensorConfig = {};
 std::map<int, conf::SkuConfig> skusConfig;
 
@@ -47,6 +53,24 @@ int main(int argc, char **argv)
     if (argc > 1)
     {
         configPath = argv[1];
+    }
+
+    debugEnabled = false;
+    if (std::filesystem::exists(debugEnablePath))
+    {
+        debugEnabled = true;
+        std::cerr << "Debug logging enabled\n";
+    }
+
+    // TODO(): This changes default behavior,
+    // from fail-if-all to fail-if-one sensor broken,
+    // which may be surprising to other users,
+    // so consider changing this before releasing.
+    spofEnabled = true;
+    if (std::filesystem::exists(spofDisablePath))
+    {
+        spofEnabled = false;
+        std::cerr << "Single point of failure disabled\n";
     }
 
     run(configPath);


### PR DESCRIPTION
TODO(): Integrate with proper command parsing,
when this is merged in:
https://github.com/quanta-bmc/read-margin-temp/commit/58a81bf63e4ebb026b2272bbadc8c707b5c25a5b

TODO(): If merged as-is, this will change default behavior,
so it would be safer to have SPOF mode default to disabled,
instead of defaulting to enabled.

TODO(): Test the file-based I/O, make sure it did not break,
as I have only tested it with D-Bus I/O.

Cleaning up std::isnan() usage to std::isfinite(),
which catches more weird floating-point things like +Inf.

Added spofEnabled global option,
enabling it by default, although this should be changed,
to avoid breaking upstream users unexpectedly.

Better istream-to-double reader that catches errors,
although this is not needed for our usage,
adding it for completeness and upstream users.

Flagging errors that happen during sensor reading,
to catch failure-of-any sensor, not just failure-of-all, and
converting failure-of-any to failure-of-all if spofEnabled.

Signed-off-by: Josh Lehan <krellan@google.com>