### PR TITLE
Add option and function according issue #11 :

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # read-margin-temp
 
 This daemon is to calculate and update margin temperatures for
-[fan PID control](https://github.com/openbmc/phosphor-pid-control). The margin
-temperatures are updated one by one with 1 second interval between each zone.
-The unit of margin temperature is millidegree.
+[fan PID control](https://github.com/openbmc/phosphor-pid-control).   
+The margin temperatures are updated one by one with 1 second interval between each zone.  
+The unit of margin temperature is millidegree.  
+This daemon will check sensor threshold and functional dbus property.
+If functional dbus is false, which means driver is not update value to dbus, 
+it will set NaN to sensor dbus value.
 
 ## Configuration File
 
-The configuration file has "sensors" and "skus" parts. The "sensors" part
-contains all the information of sensors, including paths for temperature
-reading and paths for spec temperature. The "skus" part has the list of all
-sku configurations. The detailed introduction is listed below.
+The configuration file has "sensors" and "skus" parts.  
+The "sensors" part contains all the information of sensors,
+including paths for temperature reading and paths for spec temperature.  
+The "skus" part has the list of all sku configurations.  
+The detailed introduction is listed below.
 
 # Sensor Configuration
 

--- a/dbus/dbus.hpp
+++ b/dbus/dbus.hpp
@@ -15,6 +15,9 @@ using PropertyMap =
 
 constexpr auto DBUSPROPERTYINTERFACE = "org.freedesktop.DBus.Properties";
 constexpr auto VALUEINTERFACE = "xyz.openbmc_project.Sensor.Value";
+constexpr auto FUNCTIONALINTERFACE = "xyz.openbmc_project.State.Decorator.OperationalStatus";
+constexpr auto WARNINGINTERFACE = "xyz.openbmc_project.Sensor.Threshold.Warning";
+constexpr auto CRITICALINTERFACE = "xyz.openbmc_project.Sensor.Threshold.Critical";
 
 namespace dbus
 {
@@ -126,6 +129,109 @@ class SDBusPlus
                 // std::cerr << "Sensor Value reading not available: " << path << std::endl;
             }
             return value;
+        }
+        /**
+         * Check dbus sensor WarningAlarm property.
+         *
+         * @param[in] bus - bus.
+         * @param[in] service - dbus service name.
+         * @param[in] path - dbus path.
+         * @param[in] property - dbus property name
+         * @return WarningAlarm property from dbus
+         */
+        static bool checkWarningProperty(sdbusplus::bus::bus& bus,
+                                         const std::string& service,
+                                         const std::string& path,
+                                         const std::string& property)
+        {
+            PropertyMap propMap;
+            auto pimMsg = bus.new_method_call(service.c_str(), path.c_str(),
+                DBUSPROPERTYINTERFACE, "GetAll");
+            pimMsg.append(WARNINGINTERFACE);
+
+            bool warningAlarm = false;
+
+            try
+            {
+                auto warningHighResponseMsg = bus.call(pimMsg);
+                warningHighResponseMsg.read(propMap);
+                warningAlarm = std::get<bool>(propMap[property]);
+            }
+            catch (const std::exception& e)
+            {
+                // std::cerr << "Get WarningAlarm property failed." << std::endl;
+            }
+
+            // std::cerr << property << " : " << warningAlarm << std::endl;
+            return warningAlarm;
+        }
+        /**
+         * Check dbus sensor CriticalAlarm property.
+         *
+         * @param[in] bus - bus.
+         * @param[in] service - dbus service name.
+         * @param[in] path - dbus path.
+         * @param[in] property - dbus property name
+         * @return CriticalAlarm property from dbus
+         */
+        static bool checkCriticalProperty(sdbusplus::bus::bus& bus,
+                                          const std::string& service,
+                                          const std::string& path,
+                                          const std::string& property)
+        {
+            PropertyMap propMap;
+            auto pimMsg = bus.new_method_call(service.c_str(), path.c_str(),
+                DBUSPROPERTYINTERFACE, "GetAll");
+            pimMsg.append(CRITICALINTERFACE);
+
+            bool criticalAlarm = false;
+
+            try
+            {
+                auto criticalHighResponseMsg = bus.call(pimMsg);
+                criticalHighResponseMsg.read(propMap);
+                criticalAlarm = std::get<bool>(propMap[property]);
+            }
+            catch (const std::exception& e)
+            {
+                // std::cerr << "Get CriticalAlarm property failed." << std::endl;
+            }
+
+            // std::cerr << property << " : " << criticalAlarm << std::endl;
+            return criticalAlarm;
+        }
+        /**
+         * Get dbus sensor functional property.
+         *
+         * @param[in] bus - bus.
+         * @param[in] service - dbus service name.
+         * @param[in] path - dbus path.
+         * @return Functional property from dbus
+         */
+        static bool checkFunctionalProperty(sdbusplus::bus::bus& bus,
+                                            const std::string& service,
+                                            const std::string& path)
+        {
+            PropertyMap propMap;
+            auto pimMsg = bus.new_method_call(service.c_str(), path.c_str(),
+                DBUSPROPERTYINTERFACE, "GetAll");
+            pimMsg.append(FUNCTIONALINTERFACE);
+
+            bool functional = true;
+
+            try
+            {
+                auto functionalResponseMsg = bus.call(pimMsg);
+                functionalResponseMsg.read(propMap);
+                functional = std::get<bool>(propMap["Functional"]);
+            }
+            catch (const std::exception& e)
+            {
+                // std::cerr << "Get Functional property failed." << std::endl;
+            }
+
+            // std::cerr << "Functional : " << functional << std::endl;
+            return functional;
         }
 };
 }

--- a/main.cpp
+++ b/main.cpp
@@ -20,6 +20,8 @@ extern bool debugEnabled;
 constexpr auto spofDisablePath = "/etc/thermal.d/spofdisable";
 extern bool spofEnabled;
 
+extern bool ignoreEnable;
+
 std::map<std::string, struct conf::SensorConfig> sensorConfig = {};
 std::map<int, conf::SkuConfig> skusConfig;
 
@@ -31,7 +33,10 @@ void printHelp()
     std::cout << "        default : " << MARGINCONFIGPATH << std::endl;
     std::cout << "    --loose, -l : ignore a sensor lost"
               << std::endl;
-    std::cout << "        default : consider sensor lost" << std::endl;
+    std::cout << "    --debug, -d : enable debug mode to print log"
+              << std::endl;
+    std::cout << "    --ignore, -g : enable to ignore if sensor service is empty"
+              << std::endl;
     std::cout << "" << std::endl;
 }
 
@@ -63,7 +68,7 @@ int main(int argc, char **argv)
 {
     std::string configPath = MARGINCONFIGPATH;
 
-    bool inValiedoption = false;
+    bool invalidOption = false;
 
     debugEnabled = false;
     if (std::filesystem::exists(debugEnablePath))
@@ -94,14 +99,22 @@ int main(int argc, char **argv)
         {
             spofEnabled = false;
         }
+        else if (std::strcmp(argv[i], "--debug") == 0 || std::strcmp(argv[i], "-d") == 0)
+        {
+            debugEnabled = true;
+        }
+        else if (std::strcmp(argv[i], "--ignore") == 0 || std::strcmp(argv[i], "-g") == 0)
+        {
+            ignoreEnable = true;
+        }
         else
         {
-            inValiedoption = true;
+            invalidOption = true;
             printHelp();
         }
     }
 
-    if (!inValiedoption)
+    if (!invalidOption)
     {
         run(configPath);
     }

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <filesystem>
 #include <string>
 #include <map>
 
@@ -21,6 +22,18 @@ extern bool spofEnabled;
 
 std::map<std::string, struct conf::SensorConfig> sensorConfig = {};
 std::map<int, conf::SkuConfig> skusConfig;
+
+void printHelp()
+{
+    std::cout << "Option : " << std::endl;
+    std::cout << "    --file, -f [path]: the direct path of config file"
+              << std::endl;
+    std::cout << "        default : " << MARGINCONFIGPATH << std::endl;
+    std::cout << "    --loose, -l : ignore a sensor lost"
+              << std::endl;
+    std::cout << "        default : consider sensor lost" << std::endl;
+    std::cout << "" << std::endl;
+}
 
 void run(const std::string& configPath)
 {
@@ -50,10 +63,7 @@ int main(int argc, char **argv)
 {
     std::string configPath = MARGINCONFIGPATH;
 
-    if (argc > 1)
-    {
-        configPath = argv[1];
-    }
+    bool inValiedoption = false;
 
     debugEnabled = false;
     if (std::filesystem::exists(debugEnablePath))
@@ -73,7 +83,28 @@ int main(int argc, char **argv)
         std::cerr << "Single point of failure disabled\n";
     }
 
-    run(configPath);
+    for (int i = 1; i < argc; i++)
+    {
+        if (std::strcmp(argv[i], "--file") == 0 || std::strcmp(argv[i], "-f") == 0)
+        {
+            configPath = argv[i + 1];
+            i++;
+        }
+        else if (std::strcmp(argv[i], "--loose") == 0 || std::strcmp(argv[i], "-l") == 0)
+        {
+            spofEnabled = false;
+        }
+        else
+        {
+            inValiedoption = true;
+            printHelp();
+        }
+    }
+
+    if (!inValiedoption)
+    {
+        run(configPath);
+    }
 
     return 0;
 }

--- a/util/util.hpp
+++ b/util/util.hpp
@@ -17,6 +17,7 @@ int getSkuNum();
  * Get sensor temp from dbus.
  *
  * @param[in] sensorDbusPath - sensor dbus path.
+ * @param[in] unitMilli - the value is degree(false) or millidegree(true)
  * @return Sensor temp.
  */
 double getSensorDbusTemp(std::string sensorDbusPath, bool unitMilli);


### PR DESCRIPTION
1. Option
    --file, -f [path] : set config file path
         default : /usr/share/read-margin-temp/config.json
    --loose, -l : If have this option,
              ignore a sensor failed in that zone group

2. When detect sensor Functional, WarningAlarm, CtriticalAlarm property fail,
   set target dbus value to NaN. If Functional property is false, set NaN to sensor value.

Signed-off-by: Harvey Wu <Harvey.Wu@quantatw.com>