### PR TITLE
Reuse DBus connections and reduce redundant DBus messages

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -25,6 +25,8 @@ extern bool ignoreEnable;
 std::map<std::string, struct conf::SensorConfig> sensorConfig = {};
 std::map<int, conf::SkuConfig> skusConfig;
 
+sdbusplus::bus::bus* g_system_bus, *g_default_bus;
+
 void printHelp()
 {
     std::cout << "Option : " << std::endl;
@@ -42,6 +44,12 @@ void printHelp()
 
 void run(const std::string& configPath)
 {
+    // Create DBus connections
+    auto system_bus = sdbusplus::bus::new_system();
+    auto default_bus = sdbusplus::bus::new_default();
+    g_system_bus = &system_bus;
+    g_default_bus = &default_bus;
+
     try
     {
         auto jsonData = parseValidateJson(configPath);

--- a/util/util.cpp
+++ b/util/util.cpp
@@ -15,6 +15,7 @@
 #include "sensor/sensor.hpp"
 #include "dbus/dbus.hpp"
 
+extern sdbusplus::bus::bus *g_system_bus, *g_default_bus;
 
 // Enables single-point-of-failure behavior
 bool spofEnabled = false;
@@ -61,7 +62,7 @@ double readDoubleOrNan(std::istream& is)
 
 double getSensorDbusTemp(std::string sensorDbusPath, bool unitMilli)
 {
-    auto bus = sdbusplus::bus::new_default();
+    sdbusplus::bus::bus& bus = *g_default_bus;
     std::string service = getService(sensorDbusPath);
 
     double value = std::numeric_limits<double>::quiet_NaN();
@@ -213,7 +214,7 @@ double calOffsetValue(int setPointInt,
 
 std::string getService(const std::string dbusPath)
 {
-    auto bus = sdbusplus::bus::new_system();
+    sdbusplus::bus::bus& bus = *g_system_bus;
     auto mapper =
         bus.new_method_call("xyz.openbmc_project.ObjectMapper",
                             "/xyz/openbmc_project/object_mapper",
@@ -248,8 +249,8 @@ void updateDbusMarginTemp(int zoneNum,
                           double marginTemp,
                           std::string targetPath)
 {
-    auto bus = sdbusplus::bus::new_default();
-    std::string service = getService(targetPath);
+    sdbusplus::bus::bus& bus = *g_default_bus;
+	std::string service = getService(targetPath);
 
     if (service.empty())
     {


### PR DESCRIPTION
sdbusplus functions new_default() and new_system() are used inside
getSkyNum(), getService() and updateDbusMarginTemp() in util.cpp.

sdbusplus keeps track of reference numbers and will deconstruct the
bus connection when the functions are finished. This will lead to a lot
of DBus messages that look like the following:

method call time=343242.191228 sender=:1.24309409 ->
  destination=org.freedesktop.DBus serial=1 path=/org/freedesktop/DBus;
  interface=org.freedesktop.DBus; member=Hello
signal time=343242.191694 sender=org.freedesktop.DBus ->
  destination=:1.24309409 serial=4294967295 path=/org/freedesktop/DBus;
  interface=org.freedesktop.DBus; member=NameAcquired
signal time=343242.207671 sender=org.freedesktop.DBus ->
  destination=:1.24309409 serial=4294967295 path=/org/freedesktop/DBus;
  interface=org.freedesktop.DBus; member=NameLost

This patch creates one bus object for the system and default buses and
reuses them throughout the updateMarginTempLoop, thus reducing the
occurrence of the DBus messages.