### PR TITLE
Treat missing NVMe similar to other missing services

### DIFF
--- a/util/util.cpp
+++ b/util/util.cpp
@@ -85,7 +85,12 @@ double getSensorDbusTemp(std::string sensorDbusPath, bool unitMilli)
                                                        nvmeService,
                                                        nvmeInventoryPath))
         {
-            return std::numeric_limits<double>::min();
+            // Treat missing NVMe similarly to other missing services
+            if (ignoreEnable)
+            {
+                emptyService = true;
+            }
+            return value;
         }
     }
 


### PR DESCRIPTION
Instead of returning floating-point "min", which is incorrect, simply
treat missing NVMe similar to other missing devices, and preserve
the existing behavior of returning floating-point NaN if missing.

Signed-off-by: Josh Lehan <krellan@google.com>