### PR TITLE
Caching services and values for fast performance

### DIFF
--- a/dbus/dbus.hpp
+++ b/dbus/dbus.hpp
@@ -33,8 +33,9 @@ class SDBusPlus
          * @param[in] objPath - object path.
          * @param[in] value - value to be set, in degrees, regardless of unitMilli.
          * @param[in] unitMilli - true to set millidegrees, false to set degrees.
+         * @return True if successful, false if error
          */
-        static void setValueProperty(sdbusplus::bus::bus& bus,
+        static bool setValueProperty(sdbusplus::bus::bus& bus,
                                      const std::string& busName,
                                      const std::string& objPath,
                                      const double& value,
@@ -63,12 +64,15 @@ class SDBusPlus
                     methodCall.append(std::variant<double>(value));
                 }
 
-                auto reply = bus.call(methodCall);
+                bus.call_noreply(methodCall);
             }
             catch (const std::exception& e)
             {
                 std::cerr << "Set dbus properties fail. " << e.what() << std::endl;
+                return false;
             }
+
+            return true;
         }
 
         /**

--- a/util/util.hpp
+++ b/util/util.hpp
@@ -52,7 +52,7 @@ double calOffsetValue(int setPointInt,
  * @param[in] dbusPath - sensor dbus path.
  * @return Dbus service name.
  */
-std::string getService(const std::string dbusPath, std::string interfacePath);
+std::string getService(const std::string& dbusPath, const std::string& interfacePath);
 
 /**
  * Update margin temp of zone zoneNum.


### PR DESCRIPTION
Adding service cache, to avoid repeated calls to getService(), as the
returned information is unlikely to change. Any error resulting from
calling the service will clear this cache, in case the service name
actually did change.

Adding value cache, to cache the last good value received, from each
sensor. Using D-Bus message notifications, to become aware of changes
to a sensor, instead of polling the value every time through the main
loop. This avoids repeated polling for sensors which are maintaining
a stable temperature. Only good readings are cached, any invalid
reading also clears this cache.

An optional timeout feature is also added, in case message
notifications are not working well on your system. After the timeout,
the value cache for this sensor will be cleared, even if the reading
was good, so another poll will then be made.

A separate cache debugging flag is also added, so it can be enabled
independently of the main margin zone computation debugging flag.

Tested: Works nicely locally for me, sensor loop now is much faster.

Signed-off-by: Josh Lehan <krellan@google.com>